### PR TITLE
fix: center toast positioning on mobile viewports

### DIFF
--- a/src/components/GooeyToast.css
+++ b/src/components/GooeyToast.css
@@ -17,6 +17,15 @@
   width: fit-content !important;
 }
 
+/* Fix mobile centering: override Sonner's mobile offset variables for center positions */
+@media only screen and (max-width: 600px) {
+  [data-sonner-toaster][data-x-position='center'] {
+    left: 50% !important;
+    right: auto !important;
+    transform: translateX(-50%) !important;
+  }
+}
+
 /* Style detection marker — used by GooeyToaster to verify CSS is loaded */
 [data-gooey-toast-css] { --gooey-toast: 1; }
 


### PR DESCRIPTION
## Problem
Toast notifications with `position="top-center"` or `position="bottom-center"` were not properly centered on mobile viewports (≤600px). They appeared offset to the right due to Sonner's mobile-specific CSS variables (`--mobile-offset-left`/`--mobile-offset-right`).

## Solution
Added a mobile media query that overrides Sonner's default mobile positioning for center positions by:
- Targeting the toaster container (`[data-sonner-toaster][data-x-position='center']`)
- Using `left: 50%` + `transform: translateX(-50%)` for proper centering
- Applying on viewports ≤600px

## Testing
Tested on mobile viewport (Chrome DevTools device toolbar) with:
- `position="top-center"`
- `position="bottom-center"`

Both positions now display perfectly centered with equal left/right spacing.

## Changes
- Modified [src/components/GooeyToast.css] to add mobile-specific centering override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed toast notification alignment on mobile devices to display properly centered on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->