### PR TITLE
feat: add global showTimestamp configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-04-10
+
+### Added
+
+- Global `showTimestamp` configuration on `GooeyToaster` to enable/disable timestamps for all toasts by default
+- Per-toast `showTimestamp` override still available to prioritize specific notifications
+
 ## [0.4.0] - 2026-03-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ The close button inherits the toast's border and fill color styling. Hidden duri
 
 ### Hiding Timestamps
 
+```tsx
 // Per-toast: hide timestamp for this toast only
 gooeyToast.success('Saved', { showTimestamp: false })
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Props for the `<GooeyToaster />` component.
 | `queueOverflow` | `'drop-oldest' \| 'drop-newest'`   | `'drop-oldest'`  | Queue overflow strategy                       |
 | `dir`        | `'ltr' \| 'rtl'`                     | `'ltr'`          | Layout direction                              |
 | `swipeToDismiss` | `boolean`                         | `true`           | Enable swipe-to-dismiss on mobile             |
+| `showTimestamp` | `boolean`                         | `true`           | Show/hide timestamp on all toasts globally     |
 
 ### `GooeyPromiseData<T>`
 
@@ -439,10 +440,11 @@ The close button inherits the toast's border and fill color styling. Hidden duri
 
 ### Hiding Timestamps
 
-Hide the timestamp from toasts:
-
-```tsx
+// Per-toast: hide timestamp for this toast only
 gooeyToast.success('Saved', { showTimestamp: false })
+
+// Globally: hide timestamp for all toasts
+<GooeyToaster showTimestamp={false} />
 ```
 
 ## Exports

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1219,7 +1219,7 @@ gooeyToast.success('Deployed', {
                     <tr><td>spring</td><td>boolean</td><td>Enable spring/bounce animations (default true)</td></tr>
                     <tr><td>bounce</td><td>number</td><td>Spring intensity: 0.05 (subtle) to 0.8 (dramatic), default 0.4</td></tr>
                     <tr><td>showProgress</td><td>boolean</td><td>Show countdown progress bar on this toast</td></tr>
-                    <tr><td>showTimestamp</td><td>boolean</td><td>Show/hide timestamp on this toast (default true)</td></tr>
+                    <tr><td>showTimestamp</td><td>boolean</td><td>Show/hide timestamp on this toast; when omitted, inherits <code>GooeyToaster.showTimestamp</code> (default <code>true</code>)</td></tr>
                     <tr><td>preset</td><td>AnimationPresetName</td><td>Named animation preset (smooth, bouncy, subtle, snappy)</td></tr>
                     <tr><td>onDismiss</td><td>(id: string | number) =&gt; void</td><td>Callback fired when toast is dismissed (any reason)</td></tr>
                     <tr><td>onAutoClose</td><td>(id: string | number) =&gt; void</td><td>Callback fired only when toast auto-closes (timer)</td></tr>

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1187,6 +1187,7 @@ gooeyToast.success('Deployed', {
                     <tr><td>queueOverflow</td><td>'drop-oldest' | 'drop-newest'</td><td>'drop-oldest'</td><td>Behavior when queue exceeds maxQueue</td></tr>
                     <tr><td>swipeToDismiss</td><td>boolean</td><td>true</td><td>Enable swipe-to-dismiss touch gestures on mobile</td></tr>
                     <tr><td>preset</td><td>AnimationPresetName</td><td>—</td><td>Named animation preset (smooth, bouncy, subtle, snappy)</td></tr>
+                    <tr><td>showTimestamp</td><td>boolean</td><td>true</td><td>Show/hide timestamp on all toasts globally</td></tr>
                   </tbody>
                 </table>
                 </div>
@@ -1218,6 +1219,7 @@ gooeyToast.success('Deployed', {
                     <tr><td>spring</td><td>boolean</td><td>Enable spring/bounce animations (default true)</td></tr>
                     <tr><td>bounce</td><td>number</td><td>Spring intensity: 0.05 (subtle) to 0.8 (dramatic), default 0.4</td></tr>
                     <tr><td>showProgress</td><td>boolean</td><td>Show countdown progress bar on this toast</td></tr>
+                    <tr><td>showTimestamp</td><td>boolean</td><td>Show/hide timestamp on this toast (default true)</td></tr>
                     <tr><td>preset</td><td>AnimationPresetName</td><td>Named animation preset (smooth, bouncy, subtle, snappy)</td></tr>
                     <tr><td>onDismiss</td><td>(id: string | number) =&gt; void</td><td>Callback fired when toast is dismissed (any reason)</td></tr>
                     <tr><td>onAutoClose</td><td>(id: string | number) =&gt; void</td><td>Callback fired only when toast auto-closes (timer)</td></tr>

--- a/src/components/GooeyToast.tsx
+++ b/src/components/GooeyToast.tsx
@@ -4,7 +4,7 @@ import { toast as sonnerToast } from 'sonner'
 import type { GooeyToastAction, GooeyToastClassNames, GooeyToastPhase, GooeyToastTimings, GooeyToastType } from '../types'
 import type { AnimationPresetName } from '../presets'
 import { animationPresets } from '../presets'
-import { getGooeyPosition, getGooeyDir, getGooeySpring, getGooeyBounce, getGooeySwipeToDismiss, getGooeyTheme, getGooeyShowProgress, getGooeyCloseButton, subscribeContainerHovered, getContainerHovered } from '../context'
+import { getGooeyPosition, getGooeyDir, getGooeySpring, getGooeyBounce, getGooeySwipeToDismiss, getGooeyTheme, getGooeyShowProgress, getGooeyCloseButton, subscribeContainerHovered, getContainerHovered, getGooeyShowTimestamp } from '../context'
 import { DefaultIcon, SuccessIcon, ErrorIcon, WarningIcon, InfoIcon, SpinnerIcon } from '../icons'
 import { usePrefersReducedMotion } from '../usePrefersReducedMotion'
 import { styles } from './gooey-styles'
@@ -376,7 +376,7 @@ export const GooeyToast: FC<GooeyToastProps> = ({
   preset,
   spring: springProp,
   bounce: bounceProp,
-  showTimestamp = true,
+  showTimestamp: showTimestampProp,
   showProgress: showProgressProp,
   toastId,
 }) => {
@@ -396,6 +396,7 @@ export const GooeyToast: FC<GooeyToastProps> = ({
   const useSpring = springProp ?? presetConfig?.spring ?? getGooeySpring()
   const bounceVal = bounceProp ?? presetConfig?.bounce ?? getGooeyBounce() ?? 0.4
   const showProgress = showProgressProp ?? getGooeyShowProgress()
+  const showTimestamp = showTimestampProp ?? getGooeyShowTimestamp()
 
   // Action success override state
   const [actionSuccess, setActionSuccess] = useState<string | null>(null)

--- a/src/components/GooeyToaster.tsx
+++ b/src/components/GooeyToaster.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { Toaster } from 'sonner'
 import type { GooeyToasterProps } from '../types'
 import { animationPresets } from '../presets'
-import { setGooeyPosition, setGooeyDir, setGooeySpring, setGooeyBounce, setGooeyVisibleToasts, setContainerHovered, setGooeySwipeToDismiss, setGooeyCloseOnEscape, setGooeyTheme, setGooeyMaxQueue, setGooeyQueueOverflow, setGooeyShowProgress, setGooeyCloseButton } from '../context'
+import { setGooeyPosition, setGooeyDir, setGooeySpring, setGooeyBounce, setGooeyVisibleToasts, setContainerHovered, setGooeySwipeToDismiss, setGooeyCloseOnEscape, setGooeyTheme, setGooeyMaxQueue, setGooeyQueueOverflow, setGooeyShowProgress, setGooeyCloseButton, setGooeyShowTimestamp } from '../context'
 import { gooeyToast, _getMostRecentActiveId } from '../gooey-toast'
 import { AriaLiveAnnouncer } from './AriaLiveAnnouncer'
 
@@ -26,6 +26,7 @@ export function GooeyToaster({
   maxQueue = Infinity,
   queueOverflow = 'drop-oldest',
   showProgress = false,
+  showTimestamp = true,
 }: GooeyToasterProps) {
   const presetConfig = preset ? animationPresets[preset] : undefined
   const resolvedSpring = spring ?? presetConfig?.spring ?? true
@@ -94,6 +95,10 @@ export function GooeyToaster({
   useEffect(() => {
     setGooeyCloseButton(closeButton ?? false)
   }, [closeButton])
+
+  useEffect(() => {
+    setGooeyShowTimestamp(showTimestamp)
+  }, [showTimestamp])
 
   // Detect hover on the Sonner container and broadcast to all GooeyToast instances.
   // Uses Sonner's `data-expanded` attribute (set per-toast <li>) as the hover signal

--- a/src/context.ts
+++ b/src/context.ts
@@ -110,6 +110,16 @@ export function getGooeyShowProgress() {
   return _showProgress
 }
 
+let _showTimestamp = true
+
+export function setGooeyShowTimestamp(show: boolean) {
+  _showTimestamp = show
+}
+
+export function getGooeyShowTimestamp() {
+  return _showTimestamp
+}
+
 let _closeButton: boolean | 'top-left' | 'top-right' = false
 
 export function setGooeyCloseButton(value: boolean | 'top-left' | 'top-right') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,4 +123,5 @@ export interface GooeyToasterProps {
   maxQueue?: number
   queueOverflow?: 'drop-oldest' | 'drop-newest'
   showProgress?: boolean
+  showTimestamp?: boolean
 }


### PR DESCRIPTION
## Description
Add a global `showTimestamp` configuration to `GooeyToaster` to allow users to enable or disable timestamps across all notifications.

### Key Changes
- Added `showTimestamp` prop to `GooeyToaster` (defaults to `true`).
- Per-toast `showTimestamp` override still available.
- Updated documentation in `README.md` and the demo app.
- Updated `CHANGELOG.md` with the latest version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global showTimestamp option to control timestamp visibility across all toasts by default, while retaining per-toast overrides for selective control.
  * Added a changelog entry for version 0.4.1 documenting the new behavior.

* **Documentation**
  * Updated API docs, README examples, and demo usage to show the global showTimestamp prop and per-toast suppression patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->