### PR TITLE
fix: smooth stack hover transitions without overlap flash

### DIFF
--- a/src/components/GooeyToast.css
+++ b/src/components/GooeyToast.css
@@ -29,13 +29,17 @@
 /* Style detection marker — used by GooeyToaster to verify CSS is loaded */
 [data-gooey-toast-css] { --gooey-toast: 1; }
 
-/* When Sonner expands the stack (hover), shorten height/transform CSS transitions
-   so our syncSonnerHeights corrections apply quickly (~150ms instead of 400ms).
-   Sonner writes stale --offset values from its React state; 400ms correction
-   causes visible overlap. 150ms is fast enough to prevent overlap while keeping
-   stacking spread and entry animations smooth. */
+/* When Sonner expands the stack (hover), our syncSonnerHeights corrections are
+   applied synchronously (before paint) by the shared MutationObserver, so the
+   transform/height transition target is always the correct value — there is no
+   stale-offset frame to cause overlap. This lets us use a smooth ease-out curve
+   over a longer duration so toasts glide between stacked positions instead of
+   snapping. */
 [data-sonner-toast][data-expanded="true"] {
-  transition: transform 0.15s, opacity 0.4s, height 0.15s, box-shadow 0.2s !important;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1),
+              opacity 0.4s,
+              height 0.35s cubic-bezier(0.22, 1, 0.36, 1),
+              box-shadow 0.2s !important;
 }
 
 

--- a/src/components/GooeyToast.css
+++ b/src/components/GooeyToast.css
@@ -42,6 +42,12 @@
               box-shadow 0.2s !important;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  [data-sonner-toast][data-expanded="true"] {
+    transition: opacity 0.01s, box-shadow 0.01s !important;
+  }
+}
+
 
 /* ============================================
    Wrapper — single container for both states

--- a/src/components/GooeyToast.tsx
+++ b/src/components/GooeyToast.tsx
@@ -116,8 +116,13 @@ function registerSonnerObserver(ol: Element, callback: () => void) {
     // re-trigger the observer (avoiding an infinite loop), then reconnect.
     const observer = new MutationObserver(() => {
       observer.disconnect()
-      callbacks.forEach(cb => cb())
-      observer.observe(ol, observeOptions)
+      try {
+        for (const cb of callbacks) {
+          cb()
+        }
+      } finally {
+        observer.observe(ol, observeOptions)
+      }
     })
     observer.observe(ol, observeOptions)
     entry = { observer, callbacks }

--- a/src/components/GooeyToast.tsx
+++ b/src/components/GooeyToast.tsx
@@ -100,21 +100,26 @@ function registerSonnerObserver(ol: Element, callback: () => void) {
   let entry = observerRegistry.get(ol)
   if (!entry) {
     const callbacks = new Set<() => void>()
-    let applying = false
-    const observer = new MutationObserver(() => {
-      if (applying) return
-      applying = true
-      requestAnimationFrame(() => {
-        callbacks.forEach(cb => cb())
-        requestAnimationFrame(() => { applying = false })
-      })
-    })
-    observer.observe(ol, {
+    const observeOptions: MutationObserverInit = {
       attributes: true,
       attributeFilter: ['style', 'data-visible'],
       subtree: true,
       childList: true,
+    }
+    // Correct offsets synchronously within the MutationObserver microtask
+    // (which runs before paint) so Sonner's stale --offset is overwritten in
+    // the same frame it was written. This eliminates the 1-frame stale-offset
+    // flash that previously forced us to disable CSS transitions. With the
+    // stale frame gone, transitions can stay enabled for smooth stack motion.
+    //
+    // We disconnect while applying our own style writes so they don't
+    // re-trigger the observer (avoiding an infinite loop), then reconnect.
+    const observer = new MutationObserver(() => {
+      observer.disconnect()
+      callbacks.forEach(cb => cb())
+      observer.observe(ol, observeOptions)
     })
+    observer.observe(ol, observeOptions)
     entry = { observer, callbacks }
     observerRegistry.set(ol, entry)
   }
@@ -135,8 +140,9 @@ function registerSonnerObserver(ol: Element, callback: () => void) {
  * toast.custom() content. This function corrects --initial-height and --offset
  * so our morphing toasts stack correctly.
  *
- * When expanded (hovered), CSS transitions on [data-expanded="true"] are
- * overridden (GooeyToast.css) so writing these values takes effect instantly.
+ * Corrections are applied synchronously by the shared observer (before paint),
+ * so CSS transitions on [data-expanded="true"] can stay enabled and animate
+ * the stack movement smoothly without a stale-offset flash.
  *
  * DOM order: oldest toast at index 0, newest (front) at index n-1.
  * Front toast has --offset: 0; each older toast accumulates the heights of all
@@ -167,25 +173,12 @@ function syncSonnerHeights(
     return h > 0 ? h : PH
   })
 
-  // When expanded (hovered), temporarily kill CSS transitions so offset
-  // corrections apply in this paint — prevents overlap flash. The CSS shortens
-  // transitions to 150ms (GooeyToast.css) for Sonner's own changes, but our
-  // corrections must be truly instant since getBoundingClientRect above forces
-  // a layout that "locks in" stale values.
-  const isExpanded = includeOffsets && toasts[0]?.getAttribute('data-expanded') === 'true'
-  if (isExpanded) {
-    for (const t of toasts) t.style.setProperty('transition', 'none', 'important')
-  }
-
   // Always update --initial-height (the CSS height transition target).
   for (let i = 0; i < toasts.length; i++) {
     toasts[i].style.setProperty('--initial-height', `${heights[i]}px`)
   }
 
   if (!includeOffsets) {
-    if (isExpanded) {
-      for (const t of toasts) t.style.removeProperty('transition')
-    }
     return
   }
 
@@ -203,13 +196,6 @@ function syncSonnerHeights(
     if (i > 0) {
       runningOffset += heights[i] + gap
     }
-  }
-
-  if (isExpanded) {
-    // Force reflow so browser applies corrected values without transitions,
-    // then restore transitions for Sonner's own future animations.
-    void ol.offsetHeight
-    for (const t of toasts) t.style.removeProperty('transition')
   }
 }
 
@@ -1050,10 +1036,10 @@ export const GooeyToast: FC<GooeyToastProps> = ({
     const ol = wrapper.closest('[data-sonner-toast]')?.parentElement
     if (!ol) return
 
-    // Per-rAF sync: corrects --initial-height AND --offset every time Sonner
-    // overwrites them with stale values from its React state.
-    // When expanded, CSS transitions are disabled (GooeyToast.css) so corrections
-    // apply instantly without re-targeting a CSS transition mid-flight.
+    // Synchronous sync: corrects --initial-height AND --offset every time Sonner
+    // overwrites them with stale values from its React state. The shared observer
+    // runs the correction before paint, so CSS transitions stay enabled and the
+    // stack movement animates smoothly without a stale-offset overlap flash.
     const unregister = registerSonnerObserver(ol, () => {
       syncSonnerHeights(wrapper, true)
     })


### PR DESCRIPTION
## Summary
Fixes janky/snappy animation when hovering the toast stack with multiple toasts.

## What changed
- Sync Sonner stack offset/height corrections **before paint** (MutationObserver microtask) to avoid stale offset frames.
- Update `[data-expanded="true"]` transition timing/easing so stack items glide smoothly on hover.

## Why
When hovering the stack, Sonner can briefly apply stale `--offset/--initial-height` values from its internal state. If corrections land later, the stack can snap or briefly overlap/flash. Applying corrections synchronously removes the stale frame and allows smooth transitions.

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`
- Manual: created multiple toasts in demo and hovered the stack to confirm smooth re-ordering and no overlap/flash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved snapping, flicker and overlapping in toast stacks by ensuring height/offset syncs happen before paint so expanded toasts glide smoothly.

* **Style**
  * Unified and lengthened expand animation for smoother motion; preserved opacity/shadow timing.
  * Honor prefers-reduced-motion by collapsing expanded transitions to near-instant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->