### PR TITLE
fix: prevent toast title descenders from being clipped

### DIFF
--- a/src/components/GooeyToast.css
+++ b/src/components/GooeyToast.css
@@ -116,7 +116,7 @@
   line-height: 1;
   white-space: nowrap;
   color: inherit;
-  padding: 0 4px 0 2px;
+  padding: 0 4px 2px 2px;
 }
 
 .gooey-titleDefault { color: #555; }


### PR DESCRIPTION
## Summary
Fixes an issue where toast titles with descenders (e.g. `g`, `y`, `p`, `q`) appeared clipped at the bottom.

## What changed
- Adjusted `.gooey-title` styling in [src/components/GooeyToast.css](cci:7://file:///d:/Projects/Active/goey-toast/src/components/GooeyToast.css:0:0-0:0) to add a small bottom padding so descenders aren't cut off even when ellipsis + `overflow: hidden` is applied.

## Why
The title element is rendered with `overflow: hidden` (needed for `text-overflow: ellipsis`), which can clip descenders when the line box has no extra space below the baseline. A small bottom padding provides the needed room without changing layout or behavior.

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build` 
- Manual: Verified visually in the demo by firing a toast containing descenders (e.g. "Something went wrong").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted toast notification title spacing for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->