### PR TITLE
fix: respect global showTimestamp on GooeyToaster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `GooeyToaster` `showTimestamp={false}` now correctly hides timestamps on all toasts globally (fixes [#20](https://github.com/anl331/goey-toast/issues/20))
+- Promise toasts respect the global `showTimestamp` setting when no per-toast override is provided
+
 ## [0.5.0] - 2026-06-08
 
 ### Added

--- a/src/__tests__/GooeyToaster.test.tsx
+++ b/src/__tests__/GooeyToaster.test.tsx
@@ -53,6 +53,56 @@ describe('GooeyToaster', () => {
   })
 })
 
+describe('GooeyToaster showTimestamp', () => {
+  const mockCustom = toast.custom as ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockCustom.mockClear()
+    _resetQueue()
+  })
+
+  function renderToastAfterToaster(
+    toasterProps?: React.ComponentProps<typeof GooeyToaster>,
+    toastFn: () => string | number = () => gooeyToast.success('Saved!')
+  ) {
+    render(<GooeyToaster {...toasterProps} />)
+    toastFn()
+    const renderFn = mockCustom.mock.calls[0][0]
+    return render(renderFn())
+  }
+
+  it('hides timestamp globally when showTimestamp is false', () => {
+    renderToastAfterToaster({ showTimestamp: false })
+    expect(document.querySelector('[class*="timestamp"]')).toBeNull()
+  })
+
+  it('shows timestamp globally when showTimestamp is true', () => {
+    renderToastAfterToaster({ showTimestamp: true })
+    expect(document.querySelector('[class*="timestamp"]')).toBeInTheDocument()
+  })
+
+  it('allows per-toast showTimestamp=true to override global false', () => {
+    renderToastAfterToaster(
+      { showTimestamp: false },
+      () => gooeyToast.success('Saved!', { showTimestamp: true })
+    )
+    expect(document.querySelector('[class*="timestamp"]')).toBeInTheDocument()
+  })
+
+  it('hides timestamp for promise toasts when showTimestamp is false globally', async () => {
+    render(<GooeyToaster showTimestamp={false} />)
+    const promise = new Promise<string>(() => {})
+    gooeyToast.promise(promise, {
+      loading: 'Saving...',
+      success: 'Saved!',
+      error: 'Failed',
+    })
+    const renderFn = mockCustom.mock.calls[0][0]
+    render(renderFn())
+    expect(document.querySelector('[class*="timestamp"]')).toBeNull()
+  })
+})
+
 describe('GooeyToaster closeOnEscape', () => {
   const mockDismiss = toast.dismiss as ReturnType<typeof vi.fn>
   const mockCustom = toast.custom as ReturnType<typeof vi.fn>

--- a/src/components/GooeyToaster.tsx
+++ b/src/components/GooeyToaster.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useLayoutEffect } from 'react'
 import { Toaster } from 'sonner'
 import type { GooeyToasterProps } from '../types'
 import { animationPresets } from '../presets'
@@ -96,7 +96,7 @@ export function GooeyToaster({
     setGooeyCloseButton(closeButton ?? false)
   }, [closeButton])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setGooeyShowTimestamp(showTimestamp)
   }, [showTimestamp])
 

--- a/src/gooey-toast.tsx
+++ b/src/gooey-toast.tsx
@@ -190,7 +190,7 @@ function GooeyToastWrapper({
   const [description, setDescription] = useState(initialDescription)
   const [action, setAction] = useState(initialAction)
   const [currentIcon, setCurrentIcon] = useState<ReactNode | undefined>(icon)
-  const [showTimestamp, setShowTimestamp] = useState(initialShowTimestamp ?? true)
+  const [showTimestamp, setShowTimestamp] = useState<boolean | undefined>(initialShowTimestamp)
 
   // Subscribe to in-place updates for this toast's ID.
   useEffect(() => {
@@ -340,7 +340,7 @@ function PromiseToastWrapper<T>({
         preset={data.preset}
         spring={data.spring}
         bounce={data.bounce}
-        showTimestamp={data.showTimestamp ?? true}
+        showTimestamp={data.showTimestamp}
         toastId={toastId}
       />
     </ToastErrorBoundary>


### PR DESCRIPTION
## Summary

Fixes #20 — `showTimestamp={false}` on `<GooeyToaster />` had no effect on toasts created via `gooeyToast`.

## Root cause

The global `showTimestamp` prop on `GooeyToaster` correctly updates module context via `setGooeyShowTimestamp`, and `GooeyToast` already falls back to `getGooeyShowTimestamp()` when no per-toast override is passed.

However, two wrappers hard-coded `true` when the per-toast value was omitted:

1. **`GooeyToastWrapper`** — `useState(initialShowTimestamp ?? true)` always stored `true`, then passed it explicitly to `GooeyToast`, bypassing the global getter.
2. **`PromiseToastWrapper`** — `showTimestamp={data.showTimestamp ?? true}` had the same effect for promise toasts.

## Fix

- Keep per-toast `showTimestamp` as `boolean | undefined` in `GooeyToastWrapper` state so `undefined` defers to the global setting.
- Pass `data.showTimestamp` through unchanged in `PromiseToastWrapper`.
- Sync global `showTimestamp` with `useLayoutEffect` so it is applied before the first toast paints.

## Tests

Added integration tests in `GooeyToaster.test.tsx` covering:

- global `showTimestamp={false}` hides timestamps
- global `showTimestamp={true}` shows timestamps
- per-toast `showTimestamp: true` overrides global false
- promise toasts respect global false

```bash
npm test
# 99 tests passed
```